### PR TITLE
fix: Multiple issues with UDP, Http connection, Cue command

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -5,7 +5,9 @@ This module will connect to any Interactive Technologies CueServer Device.
 **Available commands for CueServer**
 
 * Custom CueScripts, following the documentation here: <http://docs.interactive-online.com/cs2/?v=1.0&l=en>
+    * As of v2.0.1, CueScripts are automatically encoded when using HTTP protocol.
 * Play Audio Files, or Stop Audio
+    * As of v2.0.1, Extra quotes are no longer needed. Example: Chime.wav not "Chime.wav"
 * Cues
 * Macros
 * Playbacks

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class cueserverInstance extends InstanceBase {
 			self.INTERVAL = null;
 		}
 
-		if (self.udp !== undefined) {
+		if (self.udp !== undefined && self.udp !== null) {
 			self.udp.destroy();
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "interactivetechnologies-cueserver",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/src/actions.js
+++ b/src/actions.js
@@ -27,11 +27,11 @@ module.exports = {
 					label: 'Audio File to Play',
 					id: 'audiofile',
 					default: '',
-					tooltip: 'Type in an audio file name for the CueServer to play out.'
+					description: 'Type in an audio file name for the CueServer to play out. Example: Chime.wav'
 				}
 			],
 			callback: async function (action) {
-				self.runCommand('Audio ' + action.options.audiofile);
+				self.runCommand(`Audio "${action.options.audiofile}"`);
 			}
 		}
 		
@@ -47,15 +47,14 @@ module.exports = {
 			name: 'Cue',
 			options: [
 				{
-					type:   'textinput',
+					type:   'number',
 					label:  'Cue Number',
 					id:     'cuenumber',
 					default: '1',
-					regex: '/^[0-999]$/'
 				}
 			],
 			callback: async function (action) {
-				self.runCommand('Cue ' + action.options.cuenumber);
+				self.runCommand(`Cue ${action.options.cuenumber} Go`);
 			}
 		}
 		
@@ -63,15 +62,14 @@ module.exports = {
 			name: 'Macro',
 			options: [
 				{
-					type: 'textinput',
+					type: 'number',
 					label: 'Macro Number',
 					id: 'macronumber',
-					default: '1',
-					regex: '/^[0-999]$/'
+					default: 1,
 				}
 			],
 			callback: async function (action) {
-				self.runCommand('Macro ' + action.options.macronumber);
+				self.runCommand(`Macro ${action.options.macronumber}`);
 			}
 		}
 		
@@ -79,15 +77,14 @@ module.exports = {
 			name: 'Playback',
 			options: [
 				{
-					type: 'textinput',
+					type: 'number',
 					label: 'Playback Number',
 					id: 'playbacknumber',
 					default: '1',
-					regex: '/^[0-999]$/'
 				}
 			],
 			callback: async function (action) {
-				self.runCommand('Playback ' + action.options.playbacknumber);
+				self.runCommand(`Playback ${action.options.playbacknumber}`);
 			}
 		}
 		

--- a/src/api.js
+++ b/src/api.js
@@ -13,7 +13,7 @@ module.exports = {
 	init_udp: function() {
 		let self = this;
 	
-		if (self.udp !== undefined) {
+		if (self.udp !== undefined && self.udp !== null) {
 			self.udp.destroy();
 			delete self.udp;
 		}
@@ -80,7 +80,10 @@ module.exports = {
 			if (self.config.protocol == 'http') {
 				let client = new Client();
 
-				let url = 'http://' + self.config.host + ':80/exe.cgi?cmd=' + cmd;
+				// Encode the command
+				const encoded = new URLSearchParams({ cmd: cmd }).toString()
+
+				let url = 'http://' + self.config.host + ':80/exe.cgi?' + encoded;
 				
 				client.get(url, function (data, response) {
 					//do something with the response
@@ -96,7 +99,7 @@ module.exports = {
 			}
 		
 			if (self.config.protocol == 'udp') {
-				if (self.udp !== undefined ) {
+				if (self.udp !== undefined && self.udp !== null) {
 					self.udp.send(cmd);
 				}
 			}

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -1,9 +1,32 @@
 module.exports = [
-	function (context, props) {
-		// This is a placeholder than now cannot be used/removed
+	function update_v2_0_1(context, props) {
+		const updatedActions = []
+
+		for (const action of props.actions) {
+			if (action.actionId === 'cuescript') {
+
+				const cmdString = `cmd=${action.options.script}`
+				const searchParams = new URLSearchParams(cmdString);
+				const cmd = searchParams.get('cmd')
+				action.options.script = cmd
+
+			  	updatedActions.push(action)
+			} else if (action.actionId === 'audio') {
+				const str = action.options.audiofile
+				const firstChar = (typeof str === 'string' && str.length > 0) ? str.charAt(0) : null
+				const lastChar = (typeof str === 'string' && str.length > 0) ? str.charAt(str.length - 1) : null
+				const isQuoted = firstChar === '"' && lastChar === '"'
+				if (isQuoted) {
+					action.options.audiofile = str.substring(1, str.length - 1)
+					updatedActions.push(action)
+				}
+			}
+		  }
+		console.log('Actions updated to v2.0.1')
+
 		return {
 			updatedConfig: null,
-			updatedActions: [],
+			updatedActions,
 			updatedFeedbacks: [],
 		}
 	},


### PR DESCRIPTION
- Fixed UDP not starting because value was set to null but it was looking for undefined.
- Bumped version to 2.0.1 in package.json.
- Enhanced HELP.md with new features introduced in v2.0.1 regarding CueScripts and audio file handling.
- Fixed the Cue action so that it has the Go command.
- Updated api.js to properly encode commands for HTTP requests.
- Removed the incorrect Regex pattern for the cue, macro, and playback commands and changed it to a number input type instead.
- Updated the Audio action so the user doesn't need to include quotes with the file name.
- Added upgrade logic in upgrades.js to handle changes in action options for audio files and CueScripts.